### PR TITLE
Require empty hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ players:
   enabled: true
 blocks:
   enabled: true
+  require-empty-hand: false # a player's main hand must be empty to sit
   right-click: true # allow sitting with right click
   left-click: false # allow sitting with left click
   blocks:

--- a/src/main/java/de/varilx/sit/listener/BlockSitListener.java
+++ b/src/main/java/de/varilx/sit/listener/BlockSitListener.java
@@ -29,15 +29,18 @@ public class BlockSitListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerInteract(PlayerInteractEvent event) {
-        if (event.getClickedBlock() == null) return;
+        Block block = event.getClickedBlock();
+        if (block == null) return;
         VaxConfiguration configuration = BaseAPI.get().getConfiguration();
         if (!configuration.getBoolean("blocks.enabled")) return;
         if (!configuration.getBoolean("enabled")) return;
-        
-        Block block = event.getClickedBlock();
         if (configuration.getStringList("blocks.blocked-worlds").contains(block.getWorld().getName())) return;
         Player player = event.getPlayer();
         if (player.isSneaking()) return;
+        if (configuration.getBoolean("blocks.require-empty-hand")) {
+            Material mat = player.getItemInHand().getType();
+            if (mat != Material.AIR) return;
+        }
         
         for (String blockStr : configuration.getStringList("blocks.blocks")) {
             if (block.getType().name().toLowerCase().contains(blockStr.toLowerCase())) {

--- a/src/main/java/de/varilx/sit/listener/BlockSitListener.java
+++ b/src/main/java/de/varilx/sit/listener/BlockSitListener.java
@@ -37,7 +37,7 @@ public class BlockSitListener implements Listener {
         if (configuration.getStringList("blocks.blocked-worlds").contains(block.getWorld().getName())) return;
         Player player = event.getPlayer();
         if (player.isSneaking()) return;
-        if (configuration.getBoolean("blocks.require-empty-hand") && !player.getItemInHand().isEmpty()) return;
+        if (configuration.getBoolean("blocks.require-empty-hand") && !player.getInventory().getItemInMainHand().isEmpty()) return;
 
         for (String blockStr : configuration.getStringList("blocks.blocks")) {
             if (block.getType().name().toLowerCase().contains(blockStr.toLowerCase())) {

--- a/src/main/java/de/varilx/sit/listener/BlockSitListener.java
+++ b/src/main/java/de/varilx/sit/listener/BlockSitListener.java
@@ -37,11 +37,8 @@ public class BlockSitListener implements Listener {
         if (configuration.getStringList("blocks.blocked-worlds").contains(block.getWorld().getName())) return;
         Player player = event.getPlayer();
         if (player.isSneaking()) return;
-        if (configuration.getBoolean("blocks.require-empty-hand")) {
-            Material mat = player.getItemInHand().getType();
-            if (mat != Material.AIR) return;
-        }
-        
+        if (configuration.getBoolean("blocks.require-empty-hand") && !player.getItemInHand().isEmpty()) return;
+
         for (String blockStr : configuration.getStringList("blocks.blocks")) {
             if (block.getType().name().toLowerCase().contains(blockStr.toLowerCase())) {
                 if (!configuration.getBoolean("blocks.right-click") && event.getAction() == Action.RIGHT_CLICK_BLOCK) return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,7 @@ players:
 
 blocks:
   enabled: true
+  require-empty-hand: false
   right-click: true
   left-click: false
   blocked-worlds:


### PR DESCRIPTION
- 'require-empty-hand' option under 'blocks' section
- update the README
- also reuse the 'block' variable to clean code